### PR TITLE
Implement more of the rules parsing, with correct operator precedence and variables

### DIFF
--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -13,33 +13,51 @@ import cadl_primitives;
 //  ============== Parser rules ==============
 //
 
-assertion: ( identifier ':' )? boolean_expr ;
+assertion: variable_declaration | boolean_assertion;
+
+variable_declaration: '$' identifier ':' identifier '::=' (boolean_expression | arithmetic_expression);
+
+boolean_assertion: ( identifier ':' )? boolean_expression ;
 
 //
 // Expressions evaluating to boolean values
 //
 
-boolean_expr: boolean_expr boolean_binop boolean_leaf
-    | boolean_leaf
+boolean_expression
+    : boolean_or_expression
+    | boolean_expression SYM_IMPLIES boolean_or_expression
     ;
+
+boolean_or_expression
+    : boolean_and_expression
+    | boolean_or_expression SYM_OR boolean_and_expression
+    ;
+
+boolean_and_expression
+	:	boolean_xor_expression
+	|	boolean_and_expression SYM_AND boolean_xor_expression
+	;
+
+boolean_xor_expression
+	:	boolean_constraint_expression
+	|	boolean_xor_expression SYM_XOR boolean_constraint_expression
+	;
+
+boolean_constraint_expression
+    : boolean_constraint
+    | boolean_leaf;
+
+
+boolean_constraint: ( adl_path | adl_relative_path ) SYM_MATCHES ('{' c_primitive_object '}' );
 
 boolean_leaf:
       boolean_literal
     | adl_path
+    | variable_reference
     | SYM_EXISTS adl_path
-    | boolean_constraint
-    | '(' boolean_expr ')'
+    | '(' boolean_expression ')'
     | arithmetic_relop_expr
     | SYM_NOT boolean_leaf
-    ;
-
-boolean_constraint: ( adl_path | adl_relative_path ) SYM_MATCHES '{' c_primitive_object '}' ;
-
-boolean_binop:
-    | SYM_AND
-    | SYM_XOR
-    | SYM_OR
-    | SYM_IMPLIES
     ;
 
 boolean_literal:
@@ -51,20 +69,37 @@ boolean_literal:
 // Expressions evaluating to arithmetic values
 //
 
-arithmetic_relop_expr: arithmetic_arith_expr relational_binop arithmetic_arith_expr ;
+arithmetic_relop_expr: arithmetic_expression relational_binop arithmetic_expression ;
+
+
+arithmetic_expression
+   : multiplying_expression
+   | arithmetic_expression plus_minus_binop multiplying_expression
+   ;
+
+multiplying_expression
+   : pow_expression
+   | multiplying_expression mult_binop pow_expression
+   ;
+
+pow_expression
+   : arithmetic_leaf
+   | <assoc=right> pow_expression '^' arithmetic_leaf
+   ;
 
 arithmetic_leaf:
       integer_value
     | real_value
     | adl_path
-    | '(' arithmetic_arith_expr ')'
+    | variable_reference
+    | '(' arithmetic_expression ')'
     | '-' arithmetic_leaf
     ;
 
-arithmetic_arith_expr: arithmetic_arith_expr arithmetic_binop arithmetic_leaf
-    | arithmetic_arith_expr '^'<assoc=right> arithmetic_leaf
-    | arithmetic_leaf
-    ;
+variable_reference: '$' identifier;
+
+plus_minus_binop: '+' | '-';
+mult_binop: '*' | '/' | '%';
 
 relational_binop:
       SYM_EQ
@@ -75,9 +110,3 @@ relational_binop:
     | SYM_GE
     ;
 
-arithmetic_binop:
-      '/'
-    | '*'
-    | '+'
-    | '-'
-    ;


### PR DESCRIPTION
Rules parsing further implemented. Had some basic tests done in archie.

Some issues remain:
- i managed to get `$test:Boolean ::= /path[id2]/attribute[id4]/value matches {|0.0..100.0|}` to parse correctly, instead of as two statements `$test:Boolean ::= /path[id2]/attribute[id4]` and `/value matches {|0.0..100.0|}`. But there's a lot of full context/ambiguity reports by ANTLR, and rightly so. Might need a fix, might work as is.
- no for_all operator yet
- no functions yet

Some things that are not clear to me in the spec:
- functions, it's syntax, use and its mapping to the AOM
- how the for_all operator should be used and what it means
- how to handle multiple results from a model_reference (everything has multi-value support in the Archie implementation)
- labels in assertions: shouldn't those have an at-code, referring to a text and description in the terminology instead of a human readable label?

plus a mistake in the spec:
- the modulo operator is listed in AOM-spec only, not in the ADL-spec

See https://github.com/nedap/archie/pull/4 for the parser, evaluator, notes on how i solves multi-valued paths and (basic) tests on this grammar.
