### PR TITLE
SPECAM-87 -- Specify the OPT 2 ADL syntax for C_ARCHETYPE_ROOT with c…

### DIFF
--- a/src/main/antlr/adl/cadl2.g4
+++ b/src/main/antlr/adl/cadl2.g4
@@ -32,7 +32,7 @@ c_regular_object:
     | c_regular_primitive_object
     ;
 
-c_archetype_root: SYM_USE_ARCHETYPE rm_type_id '[' ID_CODE ',' archetype_ref ']' c_occurrences? ;
+c_archetype_root: SYM_USE_ARCHETYPE rm_type_id '[' ID_CODE ',' archetype_ref ']' c_occurrences? ( SYM_MATCHES '{' c_attribute_def+ default_value? '}' )? ;
 
 archetype_ref : ARCHETYPE_HRID | ARCHETYPE_REF ;
 


### PR DESCRIPTION
…hild nodes

Adds the option to add matches {...} to the archetype roots, to be able to include child nodes. Linked to a change in specifications-AM, pull request at https://github.com/openEHR/specifications-AM/pull/7